### PR TITLE
chore: remove duplicate registerFallbackValue call

### DIFF
--- a/lib/src/mock_navigator.dart
+++ b/lib/src/mock_navigator.dart
@@ -47,7 +47,6 @@ class MockNavigator extends Mock
     registerFallbackValue(_FakeRoute<bool>());
     registerFallbackValue(_FakeRoute<String>());
     registerFallbackValue(_FakeRoute<num>());
-    registerFallbackValue(_FakeRoute<bool>());
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The constructor body of `MockNavigator` consisted duplicate `registerFallbackValue(_FakeRoute<bool>());`. This PR removes it.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
