### PR TITLE
feat: fixing for Flutter 3.13.0

### DIFF
--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   semantic_pull_request:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1.11.0
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1
 
   build:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1.11.0
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       flutter_channel: stable
       working_directory: example

--- a/lib/src/mock_navigator.dart
+++ b/lib/src/mock_navigator.dart
@@ -9,7 +9,7 @@ class _MockMaterialPageRoute extends MaterialPageRoute<void> {
       final state = OverlayState();
       final entry = OverlayEntry(builder: (_) => const SizedBox());
       try {
-        // We need to call insert since that is the only way to populte the
+        // We need to call insert since that is the only way to populate the
         // `_overlay` field in the entry. But that method calls a setState,
         // which will fail since we are not in a widget tree.
         //

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/VeryGoodOpenSource/mockingjay
 
 environment:
   sdk: ">=2.18.0 <3.0.0"
-  flutter: ">=3.7.3"
+  flutter: ">=3.13.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/VeryGoodOpenSource/mockingjay
 
 environment:
   sdk: ">=2.18.0 <3.0.0"
-  flutter: ">=3.13.0"
+  flutter: ">=3.7.3"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

It seems that the navigator in Flutter 3.13.0 has changed a little bit how it works internally, those changes broke Mockinjay because how it "hooks" mocks in the navigation made that some internal fields were not populated, breaking the tests when the mocked navigator was disposed.

This PR adds an addition hack in order to trick those unpopulated internal fields so it can start working again.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

Fixes #52 
