### PR TITLE
fix: Updates for Flutter 3.16.0/Dart 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ class MySettingsPage extends StatelessWidget {
 void main() {
   testWidgets('pushes SettingsPage when TextButton is tapped', (tester) async {
     final navigator = MockNavigator();
+    when(navigator.canPop).thenReturn(true);
     when(() => navigator.push<void>(any())).thenAnswer((_) async {});
 
     await tester.pumpWidget(

--- a/example/test/ui/home_screen_test.dart
+++ b/example/test/ui/home_screen_test.dart
@@ -24,6 +24,7 @@ void main() {
 
     setUp(() {
       navigator = MockNavigator();
+      when(() => navigator.canPop()).thenReturn(true);
       when(() => navigator.push<String?>(any())).thenAnswer((_) async => null);
       when(
         () => navigator.push<QuizOption>(any()),

--- a/example/test/ui/pincode_screen_test.dart
+++ b/example/test/ui/pincode_screen_test.dart
@@ -14,6 +14,7 @@ void main() {
 
     setUp(() {
       navigator = MockNavigator();
+      when(() => navigator.canPop()).thenReturn(true);
     });
 
     testWidgets('.route renders PincodeScreen', (tester) async {

--- a/example/test/ui/quiz_dialog_test.dart
+++ b/example/test/ui/quiz_dialog_test.dart
@@ -14,6 +14,7 @@ void main() {
 
     setUp(() {
       navigator = MockNavigator();
+      when(() => navigator.canPop()).thenReturn(true);
     });
 
     testWidgets('.show opens dialog', (tester) async {

--- a/lib/src/mock_navigator.dart
+++ b/lib/src/mock_navigator.dart
@@ -67,13 +67,18 @@ class MockNavigator extends Mock
     with _MockNavigatorDiagnosticsMixin
     implements NavigatorState {
   /// {@macro mock_navigator}
-  MockNavigator() {
+  ///
+  /// [canPop()] is automatically stubbed to return the value of
+  /// [initialCanPop].
+  MockNavigator({bool initialCanPop = false}) {
     registerFallbackValue(_FakeRoute<dynamic>());
     registerFallbackValue(_FakeRoute<Object>());
     registerFallbackValue(_FakeRoute<void>());
     registerFallbackValue(_FakeRoute<bool>());
     registerFallbackValue(_FakeRoute<String>());
     registerFallbackValue(_FakeRoute<num>());
+
+    when(canPop).thenReturn(initialCanPop);
   }
 
   final _routes = <_MockMaterialPageRoute>[];

--- a/lib/src/mock_navigator.dart
+++ b/lib/src/mock_navigator.dart
@@ -6,7 +6,8 @@ class _MockMaterialPageRoute extends MaterialPageRoute<void> {
 
   void hackOverlays() {
     for (var i = 0; i < overlayEntries.length; i++) {
-      final state = OverlayState();
+      // Entry can only be inserted when the state is mounted
+      final state = _MockOverlayState().._mounted = true;
       final entry = OverlayEntry(builder: (_) => const SizedBox());
       try {
         // We need to call insert since that is the only way to populate the
@@ -17,9 +18,19 @@ class _MockMaterialPageRoute extends MaterialPageRoute<void> {
         // so we just ignore the error and the hack will do its job.
         state.insert(entry);
       } catch (_) {}
+      // Set mounted back to false to make sure the state doesn't get
+      // marked as dirty during OverlayEntry.remove().
+      state._mounted = false;
       overlayEntries[i] = entry;
     }
   }
+}
+
+class _MockOverlayState extends OverlayState {
+  late bool _mounted;
+
+  @override
+  bool get mounted => _mounted;
 }
 
 class _FakeRoute<T> extends Fake implements Route<T> {}

--- a/lib/src/mock_navigator.dart
+++ b/lib/src/mock_navigator.dart
@@ -78,18 +78,13 @@ class MockNavigator extends Mock
     with _MockNavigatorDiagnosticsMixin
     implements NavigatorState {
   /// {@macro mock_navigator}
-  ///
-  /// [canPop()] is automatically stubbed to return the value of
-  /// [initialCanPop].
-  MockNavigator({bool initialCanPop = false}) {
+  MockNavigator() {
     registerFallbackValue(_FakeRoute<dynamic>());
     registerFallbackValue(_FakeRoute<Object>());
     registerFallbackValue(_FakeRoute<void>());
     registerFallbackValue(_FakeRoute<bool>());
     registerFallbackValue(_FakeRoute<String>());
     registerFallbackValue(_FakeRoute<num>());
-
-    when(canPop).thenReturn(initialCanPop);
   }
 
   final _routes = <_MockMaterialPageRoute>[];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/VeryGoodOpenSource/mockingjay
 
 environment:
   sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.7.3"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:

--- a/test/src/example_test.dart
+++ b/test/src/example_test.dart
@@ -35,6 +35,7 @@ class MySettingsPage extends StatelessWidget {
 void main() {
   testWidgets('pushes SettingsPage when TextButton is tapped', (tester) async {
     final navigator = MockNavigator();
+    when(navigator.canPop).thenReturn(true);
     when(() => navigator.push<void>(any())).thenAnswer((_) async {});
 
     await tester.pumpWidget(

--- a/test/src/mock_navigator_test.dart
+++ b/test/src/mock_navigator_test.dart
@@ -45,6 +45,7 @@ void main() {
 
     setUp(() {
       navigator = MockNavigator();
+      when(() => navigator.canPop()).thenReturn(true);
     });
 
     test('toString returns normally', () {

--- a/test/src/mock_navigator_test.dart
+++ b/test/src/mock_navigator_test.dart
@@ -198,6 +198,8 @@ void main() {
         ),
       );
 
+      // Called by NavigatorState.didChangeDependencies initially
+      verify(() => navigator.canPop()).called(1);
       await tester.tap(find.byType(TextButton));
       verify(() => navigator.canPop()).called(1);
     });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->

- `MockNavigator` constructor now contains `initialCanPop` (default `false`), which is used to stub `Navigator.canPop()` automatically; it can ofcourse be overridden afterwards by stubbing again
- Fixed `_MockMaterialPageRoute.hackOverlays()`  by creating a `_MockOverlayState` class that allows overriding of `OverlayState.mounted`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
