### PR TITLE
chore: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.5.0
 
+**Note**: This release supports [Flutter 3.16.0](https://docs.flutter.dev/release/release-notes/release-notes-3.16.0), for migration details see the [release notes](https://github.com/VeryGoodOpenSource/mockingjay/releases/tag/v0.5.0).
+
 - chore(deps): bump very_good_analysis from 4.0.0+1 to 5.1.0 ([#56](https://github.com/VeryGoodOpenSource/mockingjay/pull/56))
 - chore: update Very Good Analysis to 5.1.0 ([#57](https://github.com/VeryGoodOpenSource/mockingjay/pull/57))
 - chore: updated sdk constraints for example ([#60](https://github.com/VeryGoodOpenSource/mockingjay/pull/60))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.5.0
+
+- chore(deps): bump very_good_analysis from 4.0.0+1 to 5.1.0 ([#56](https://github.com/VeryGoodOpenSource/mockingjay/pull/56))
+- chore: update Very Good Analysis to 5.1.0 ([#57](https://github.com/VeryGoodOpenSource/mockingjay/pull/57))
+- chore: updated sdk constraints for example ([#60](https://github.com/VeryGoodOpenSource/mockingjay/pull/60))
+- docs: update installation instructions readme ([#61](https://github.com/VeryGoodOpenSource/mockingjay/pull/61))
+- fix!: Updates for Flutter 3.16.0/Dart 3.2 ([#65](https://github.com/VeryGoodOpenSource/mockingjay/pull/65))
+
 # 0.4.0
 
 - feat: support for `mocktail ^1.0.0`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockingjay
 description: A package that makes it easy to mock, test and verify navigation calls in Flutter.
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/VeryGoodOpenSource/mockingjay
 
 environment:

--- a/tool/release_ready.sh
+++ b/tool/release_ready.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Ensures that the package is ready for a release.
+# 
+# Will update the version.dart file and update the CHANGELOG.md.
+#
+# Set it up for a new version:
+# `sh tool/release_ready.sh <version>`
+
+# Check if current directory is usable for this script, if so we assume it is correctly set up.
+if [ ! -f "pubspec.yaml" ]; then
+  echo "$(pwd) is not a valid Dart package."
+  exit 1
+fi
+
+currentBranch=$(git symbolic-ref --short -q HEAD)
+if [[ ! $currentBranch == "main" ]]; then
+ echo "Releasing is only supported on the main branch."
+ exit 1
+fi
+
+# Get information
+old_version=""
+if [ -f "pubspec.yaml" ]; then
+  old_version=$(dart pub deps --json | pcregrep -o1 -i '"version": "(.*?)"' | head -1)
+fi
+
+if [ -z "$old_version" ]; then
+  echo "Current version was not resolved."
+  exit 1
+fi
+
+# Get new version
+new_version="$1";
+
+if [[ "$new_version" == "" ]]; then 
+  echo "No new version supplied, please provide one"
+  exit 1
+fi
+
+if [[ "$new_version" == "$old_version" ]]; then
+  echo "Current version is $old_version, can't update."
+  exit 1
+fi
+
+# Retrieving all the commits in the current directory since the last tag.
+previousTag="v${old_version}"
+raw_commits="$(git log --pretty=format:"%s" --no-merges --reverse $previousTag..HEAD -- .)"
+markdown_commits=$(echo "$raw_commits" | sed -En "s/\(#([0-9]+)\)/([#\1](https:\/\/github.com\/VeryGoodOpenSource\/mockingjay\/pull\/\1))/p")
+
+if [[ "$markdown_commits" == "" ]]; then
+  echo "No commits since last tag, can't update."
+  exit 0
+fi
+commits=$(echo "$markdown_commits" | sed -En "s/^/- /p")
+
+echo "Updating version to $new_version"
+if [ -f "pubspec.yaml" ]; then
+  sed -i '' "s/version: $old_version/version: $new_version/g" pubspec.yaml
+fi
+
+# Update dart file with new version.
+dart run build_runner build --delete-conflicting-outputs > /dev/null
+
+if grep -q v$new_version "CHANGELOG.md"; then
+  echo "CHANGELOG already contains version $new_version."
+  exit 1
+fi
+
+# Add a new version entry with the found commits to the CHANGELOG.md.
+echo "# ${new_version} \n\n ${commits}\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+echo "CHANGELOG generated, validate entries here: $(pwd)/CHANGELOG.md"
+
+echo "Creating git branch for mockingay@$new_version"
+git checkout -b "chore/$new_version" > /dev/null
+
+git add pubspec.yaml CHANGELOG.md 
+if [ -f lib/src/version.dart ]; then
+  git add lib/src/version.dart
+fi
+
+echo ""
+echo "Run the following command if you wish to commit the changes:"
+echo "git commit -m \"chore: v$new_version\""


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Releases v0.5.0 (compatible with Flutter 3.16.0) 🚀 

## Migration details

This breaking change now requires users to mock the `canPop` method since it is being used internally by Flutter (see https://github.com/flutter/flutter/pull/132249).

```dart
final navigator = MockNavigator();
when(() => navigator.canPop()).thenReturn(true); // New, previously not always required.
```

In addition, if you were verifying the `canPop` calls you should now expect an additional call.
```dart
verify(() => navigator.canPop()).called(1); // New, previously not always required.
await tester.tap(find.byType(TextButton));
verify(() => navigator.canPop()).called(1)
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
