### PR TITLE
chore: bumping flutter version to 3.29.0 and bumping example dependencies

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.24.0"
+          - "3.29.0"
           - "3.x"
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:

--- a/example/lib/ui/home_screen.dart
+++ b/example/lib/ui/home_screen.dart
@@ -70,9 +70,7 @@ class _HomeScreenState extends State<HomeScreen> {
     final monospaceFontFamily = Platform.isIOS ? 'Courier' : 'monospace';
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Mockingjay Example'),
-      ),
+      appBar: AppBar(title: const Text('Mockingjay Example')),
       body: Center(
         child: DefaultTextStyle.merge(
           textAlign: TextAlign.center,
@@ -91,7 +89,8 @@ class _HomeScreenState extends State<HomeScreen> {
                     TextSpan(
                       children: [
                         const TextSpan(
-                          text: 'Use one of the following buttons to trigger a '
+                          text:
+                              'Use one of the following buttons to trigger a '
                               'navigation change.\n'
                               'Check out the test files in the ',
                         ),

--- a/example/lib/ui/pincode_screen.dart
+++ b/example/lib/ui/pincode_screen.dart
@@ -51,9 +51,7 @@ class _PincodeScreenState extends State<PincodeScreen> {
     final monospaceFontFamily = Platform.isIOS ? 'Courier' : 'monospace';
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Pincode Screen'),
-      ),
+      appBar: AppBar(title: const Text('Pincode Screen')),
       body: Center(
         child: DefaultTextStyle.merge(
           textAlign: TextAlign.center,

--- a/example/lib/ui/quiz_dialog.dart
+++ b/example/lib/ui/quiz_dialog.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/cupertino.dart';
 
-enum QuizOption {
-  pizza,
-  hamburger,
-}
+enum QuizOption { pizza, hamburger }
 
 class QuizDialog extends StatelessWidget {
   const QuizDialog({super.key});

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,18 +4,18 @@ version: 0.0.1
 homepage: https://github.com/VeryGoodOpenSource/mockingjay
 
 environment:
-  sdk: ^3.5.0
+  sdk: ^3.7.0
 
 dependencies:
-  bloc: ^8.1.4
+  bloc: ^9.0.0
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_bloc: ^8.1.6
+  flutter_bloc: ^9.1.0
   universal_io: ^2.2.2
 
 dev_dependencies:
-  bloc_test: ^9.1.7
+  bloc_test: ^10.0.0
   flutter_test:
     sdk: flutter
   mockingjay:

--- a/example/test/helpers.dart
+++ b/example/test/helpers.dart
@@ -2,17 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 extension WidgetTesterX on WidgetTester {
-  Future<void> pumpTest({
-    required WidgetBuilder builder,
-  }) async {
+  Future<void> pumpTest({required WidgetBuilder builder}) async {
     await pumpWidget(
       MaterialApp(
         title: 'Mock Navigator Test',
-        home: Scaffold(
-          body: Builder(
-            builder: builder,
-          ),
-        ),
+        home: Scaffold(body: Builder(builder: builder)),
       ),
     );
   }

--- a/example/test/ui/home_screen_test.dart
+++ b/example/test/ui/home_screen_test.dart
@@ -10,10 +10,12 @@ class FakeRoute<T> extends Fake implements Route<T> {}
 
 void main() {
   group('HomeScreen', () {
-    const showPincodeScreenTextButtonKey =
-        Key('homeScreen_showPincodeScreen_textButton');
-    const showQuizDialogTextButtonKey =
-        Key('homeScreen_showQuizDialog_textButton');
+    const showPincodeScreenTextButtonKey = Key(
+      'homeScreen_showPincodeScreen_textButton',
+    );
+    const showQuizDialogTextButtonKey = Key(
+      'homeScreen_showQuizDialog_textButton',
+    );
 
     late MockNavigator navigator;
 
@@ -39,10 +41,7 @@ void main() {
           },
         );
 
-        expect(
-          find.byKey(showPincodeScreenTextButtonKey),
-          findsOneWidget,
-        );
+        expect(find.byKey(showPincodeScreenTextButtonKey), findsOneWidget);
       });
 
       testWidgets('navigates to PincodeScreen when pressed', (tester) async {
@@ -55,9 +54,7 @@ void main() {
           },
         );
 
-        await tester.tap(
-          find.byKey(showPincodeScreenTextButtonKey),
-        );
+        await tester.tap(find.byKey(showPincodeScreenTextButtonKey));
 
         verify(
           () => navigator.push<String?>(
@@ -91,37 +88,32 @@ void main() {
         );
       });
 
-      testWidgets(
-        'displays snackbar when no pincode was submitted',
-        (tester) async {
-          when(
-            () => navigator.push<String?>(
-              any(
-                that: isRoute<String?>(
-                  whereName: equals('/pincode_screen'),
-                ),
-              ),
-            ),
-          ).thenAnswer((_) async => null);
+      testWidgets('displays snackbar when no pincode was submitted', (
+        tester,
+      ) async {
+        when(
+          () => navigator.push<String?>(
+            any(that: isRoute<String?>(whereName: equals('/pincode_screen'))),
+          ),
+        ).thenAnswer((_) async => null);
 
-          await tester.pumpTest(
-            builder: (context) {
-              return MockNavigatorProvider(
-                navigator: navigator,
-                child: const HomeScreen(),
-              );
-            },
-          );
+        await tester.pumpTest(
+          builder: (context) {
+            return MockNavigatorProvider(
+              navigator: navigator,
+              child: const HomeScreen(),
+            );
+          },
+        );
 
-          await tester.tap(find.byKey(showPincodeScreenTextButtonKey));
-          await tester.pumpAndSettle();
+        await tester.tap(find.byKey(showPincodeScreenTextButtonKey));
+        await tester.pumpAndSettle();
 
-          expect(
-            find.widgetWithText(SnackBar, 'No pincode submitted. 😲'),
-            findsOneWidget,
-          );
-        },
-      );
+        expect(
+          find.widgetWithText(SnackBar, 'No pincode submitted. 😲'),
+          findsOneWidget,
+        );
+      });
     });
 
     group('show quiz dialog button', () {
@@ -132,10 +124,7 @@ void main() {
           },
         );
 
-        expect(
-          find.byKey(showQuizDialogTextButtonKey),
-          findsOneWidget,
-        );
+        expect(find.byKey(showQuizDialogTextButtonKey), findsOneWidget);
       });
 
       testWidgets('shows quiz dialog when pressed', (tester) async {
@@ -155,83 +144,78 @@ void main() {
         ).called(1);
       });
 
-      testWidgets(
-        'displays snackbar when pizza was selected',
-        (tester) async {
-          when(
-            () => navigator.push<QuizOption>(any(that: isRoute<QuizOption>())),
-          ).thenAnswer((_) async => QuizOption.pizza);
+      testWidgets('displays snackbar when pizza was selected', (tester) async {
+        when(
+          () => navigator.push<QuizOption>(any(that: isRoute<QuizOption>())),
+        ).thenAnswer((_) async => QuizOption.pizza);
 
-          await tester.pumpTest(
-            builder: (context) {
-              return MockNavigatorProvider(
-                navigator: navigator,
-                child: const HomeScreen(),
-              );
-            },
-          );
+        await tester.pumpTest(
+          builder: (context) {
+            return MockNavigatorProvider(
+              navigator: navigator,
+              child: const HomeScreen(),
+            );
+          },
+        );
 
-          await tester.tap(find.byKey(showQuizDialogTextButtonKey));
-          await tester.pumpAndSettle();
+        await tester.tap(find.byKey(showQuizDialogTextButtonKey));
+        await tester.pumpAndSettle();
 
-          expect(
-            find.widgetWithText(SnackBar, 'Pizza all the way! 🍕'),
-            findsOneWidget,
-          );
-        },
-      );
+        expect(
+          find.widgetWithText(SnackBar, 'Pizza all the way! 🍕'),
+          findsOneWidget,
+        );
+      });
 
-      testWidgets(
-        'displays snackbar when hamburger was selected',
-        (tester) async {
-          when(
-            () => navigator.push<QuizOption>(any(that: isRoute<QuizOption>())),
-          ).thenAnswer((_) async => QuizOption.hamburger);
+      testWidgets('displays snackbar when hamburger was selected', (
+        tester,
+      ) async {
+        when(
+          () => navigator.push<QuizOption>(any(that: isRoute<QuizOption>())),
+        ).thenAnswer((_) async => QuizOption.hamburger);
 
-          await tester.pumpTest(
-            builder: (context) {
-              return MockNavigatorProvider(
-                navigator: navigator,
-                child: const HomeScreen(),
-              );
-            },
-          );
+        await tester.pumpTest(
+          builder: (context) {
+            return MockNavigatorProvider(
+              navigator: navigator,
+              child: const HomeScreen(),
+            );
+          },
+        );
 
-          await tester.tap(find.byKey(showQuizDialogTextButtonKey));
-          await tester.pumpAndSettle();
+        await tester.tap(find.byKey(showQuizDialogTextButtonKey));
+        await tester.pumpAndSettle();
 
-          expect(
-            find.widgetWithText(SnackBar, 'Hamburger all the way! 🍔'),
-            findsOneWidget,
-          );
-        },
-      );
+        expect(
+          find.widgetWithText(SnackBar, 'Hamburger all the way! 🍔'),
+          findsOneWidget,
+        );
+      });
 
-      testWidgets(
-        'displays snackbar when no answer was selected',
-        (tester) async {
-          when(
-            () => navigator.push<QuizOption>(any(that: isRoute<QuizOption>())),
-          ).thenAnswer((_) async => null);
+      testWidgets('displays snackbar when no answer was selected', (
+        tester,
+      ) async {
+        when(
+          () => navigator.push<QuizOption>(any(that: isRoute<QuizOption>())),
+        ).thenAnswer((_) async => null);
 
-          await tester.pumpTest(
-            builder: (context) {
-              return MockNavigatorProvider(
-                navigator: navigator,
-                child: const HomeScreen(),
-              );
-            },
-          );
+        await tester.pumpTest(
+          builder: (context) {
+            return MockNavigatorProvider(
+              navigator: navigator,
+              child: const HomeScreen(),
+            );
+          },
+        );
 
-          await tester.tap(find.byKey(showQuizDialogTextButtonKey));
-          await tester.pumpAndSettle();
+        await tester.tap(find.byKey(showQuizDialogTextButtonKey));
+        await tester.pumpAndSettle();
 
-          expect(
-            find.widgetWithText(SnackBar, 'No answer selected. 😲'),
-            findsOneWidget,
-          );
-        },
-      );
+        expect(
+          find.widgetWithText(SnackBar, 'No answer selected. 😲'),
+          findsOneWidget,
+        );
+      });
     });
   });
 }

--- a/example/test/ui/pincode_screen_test.dart
+++ b/example/test/ui/pincode_screen_test.dart
@@ -63,22 +63,21 @@ void main() {
       },
     );
 
-    testWidgets(
-      'clamps to 6 digits when exact 6 digits have been entered',
-      (tester) async {
-        await tester.pumpTest(
-          builder: (context) {
-            return MockNavigatorProvider(
-              navigator: navigator,
-              child: const PincodeScreen(),
-            );
-          },
-        );
+    testWidgets('clamps to 6 digits when exact 6 digits have been entered', (
+      tester,
+    ) async {
+      await tester.pumpTest(
+        builder: (context) {
+          return MockNavigatorProvider(
+            navigator: navigator,
+            child: const PincodeScreen(),
+          );
+        },
+      );
 
-        await tester.enterText(find.byType(TextField), '123456');
-        verify(() => navigator.pop('123456')).called(1);
-      },
-    );
+      await tester.enterText(find.byType(TextField), '123456');
+      verify(() => navigator.pop('123456')).called(1);
+    });
 
     testWidgets(
       'clamps to 6 digits when more than 6 digits have been entered',
@@ -97,23 +96,22 @@ void main() {
       },
     );
 
-    testWidgets(
-      'shows error when less than 6 digits have been entered',
-      (tester) async {
-        await tester.pumpTest(
-          builder: (context) {
-            return MockNavigatorProvider(
-              navigator: navigator,
-              child: const PincodeScreen(),
-            );
-          },
-        );
+    testWidgets('shows error when less than 6 digits have been entered', (
+      tester,
+    ) async {
+      await tester.pumpTest(
+        builder: (context) {
+          return MockNavigatorProvider(
+            navigator: navigator,
+            child: const PincodeScreen(),
+          );
+        },
+      );
 
-        await tester.enterText(find.byType(TextField), '12345');
-        await tester.testTextInput.receiveAction(TextInputAction.done);
-        await tester.pump();
-        expect(find.text('Pincode must be 6 digits long'), findsOneWidget);
-      },
-    );
+      await tester.enterText(find.byType(TextField), '12345');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(find.text('Pincode must be 6 digits long'), findsOneWidget);
+    });
   });
 }

--- a/example/test/ui/quiz_dialog_test.dart
+++ b/example/test/ui/quiz_dialog_test.dart
@@ -41,23 +41,20 @@ void main() {
         expect(find.text('🍕'), findsOneWidget);
       });
 
-      testWidgets(
-        'pops route with pizza option when pressed',
-        (tester) async {
-          await tester.pumpTest(
-            builder: (context) {
-              return MockNavigatorProvider(
-                navigator: navigator,
-                child: const QuizDialog(),
-              );
-            },
-          );
+      testWidgets('pops route with pizza option when pressed', (tester) async {
+        await tester.pumpTest(
+          builder: (context) {
+            return MockNavigatorProvider(
+              navigator: navigator,
+              child: const QuizDialog(),
+            );
+          },
+        );
 
-          await tester.tap(find.text('🍕'));
+        await tester.tap(find.text('🍕'));
 
-          verify(() => navigator.pop(QuizOption.pizza)).called(1);
-        },
-      );
+        verify(() => navigator.pop(QuizOption.pizza)).called(1);
+      });
     });
 
     group('hamburger button', () {
@@ -71,23 +68,22 @@ void main() {
         expect(find.text('🍔'), findsOneWidget);
       });
 
-      testWidgets(
-        'pops route with hamburger option when pressed',
-        (tester) async {
-          await tester.pumpTest(
-            builder: (context) {
-              return MockNavigatorProvider(
-                navigator: navigator,
-                child: const QuizDialog(),
-              );
-            },
-          );
+      testWidgets('pops route with hamburger option when pressed', (
+        tester,
+      ) async {
+        await tester.pumpTest(
+          builder: (context) {
+            return MockNavigatorProvider(
+              navigator: navigator,
+              child: const QuizDialog(),
+            );
+          },
+        );
 
-          await tester.tap(find.text('🍔'));
+        await tester.tap(find.text('🍔'));
 
-          verify(() => navigator.pop(QuizOption.hamburger)).called(1);
-        },
-      );
+        verify(() => navigator.pop(QuizOption.hamburger)).called(1);
+      });
     });
   });
 }

--- a/lib/src/matchers.dart
+++ b/lib/src/matchers.dart
@@ -48,11 +48,7 @@ Matcher isRoute<T extends Object?>({
 /// Returns a matcher that matches the [RouteSettings] from the given [route].
 Matcher equalsSettingsOf(Route<dynamic> route) {
   return isA<RouteSettings>()
-      .having(
-        (s) => s.name,
-        'name',
-        equals(route.settings.name),
-      )
+      .having((s) => s.name, 'name', equals(route.settings.name))
       .having(
         (s) => s.arguments,
         'arguments',
@@ -188,19 +184,25 @@ class _RouteMatcher<T> extends Matcher {
     if (item is Route) {
       final typeMatches = !hasTypeArgument || item is Route<T>;
 
-      final settingsMatches = !hasSettingsMatcher ||
+      final settingsMatches =
+          !hasSettingsMatcher ||
           whereSettings!.matches(item.settings, matchState);
       final nameMatches =
           !hasNameMatcher || whereName!.matches(item.settings.name, matchState);
-      final argumentsMatches = !hasArgumentsMatcher ||
+      final argumentsMatches =
+          !hasArgumentsMatcher ||
           whereArguments!.matches(item.settings.arguments, matchState);
-      final maintainStateMatches = !hasMaintainStateMatcher ||
+      final maintainStateMatches =
+          !hasMaintainStateMatcher ||
           (item is ModalRoute &&
               whereMaintainState!.matches(item.maintainState, matchState));
-      final fullscreenDialogMatches = !hasFullscreenDialogMatcher ||
+      final fullscreenDialogMatches =
+          !hasFullscreenDialogMatcher ||
           (item is PageRoute &&
-              whereFullscreenDialog!
-                  .matches(item.fullscreenDialog, matchState));
+              whereFullscreenDialog!.matches(
+                item.fullscreenDialog,
+                matchState,
+              ));
 
       return typeMatches &&
           settingsMatches &&
@@ -229,16 +231,20 @@ class _RouteMatcher<T> extends Matcher {
 
     final typeMatches = !hasTypeArgument || item is Route<T>;
 
-    final settingsMatches = !hasSettingsMatcher ||
+    final settingsMatches =
+        !hasSettingsMatcher ||
         whereSettings!.matches(item.settings, matchState);
     final nameMatches =
         !hasNameMatcher || whereName!.matches(item.settings.name, matchState);
-    final argumentsMatches = !hasArgumentsMatcher ||
+    final argumentsMatches =
+        !hasArgumentsMatcher ||
         whereArguments!.matches(item.settings.arguments, matchState);
-    final maintainStateMatches = !hasMaintainStateMatcher ||
+    final maintainStateMatches =
+        !hasMaintainStateMatcher ||
         (item is ModalRoute &&
             whereMaintainState!.matches(item.maintainState, matchState));
-    final fullscreenDialogMatches = !hasFullscreenDialogMatcher ||
+    final fullscreenDialogMatches =
+        !hasFullscreenDialogMatcher ||
         (item is PageRoute &&
             whereFullscreenDialog!.matches(item.fullscreenDialog, matchState));
 
@@ -285,25 +291,27 @@ class _RouteMatcher<T> extends Matcher {
         mismatchDescriptions.add("the route's `arguments` $mismatch");
       }
       if (!maintainStateMatches) {
-        final mismatch = item is! ModalRoute
-            ? 'is not a property on `${item.runtimeType}` and can only be used '
-                'with `ModalRoute`s'
-            : whereMaintainState!.describeMismatchAsString(
-                item.maintainState,
-                matchState,
-                verbose: verbose,
-              );
+        final mismatch =
+            item is! ModalRoute
+                ? 'is not a property on `${item.runtimeType}` and can only be used '
+                    'with `ModalRoute`s'
+                : whereMaintainState!.describeMismatchAsString(
+                  item.maintainState,
+                  matchState,
+                  verbose: verbose,
+                );
         mismatchDescriptions.add('`maintainState` $mismatch');
       }
       if (!fullscreenDialogMatches) {
-        final mismatch = item is! PageRoute
-            ? 'is not a property on `${item.runtimeType}` and can only be used '
-                'with `PageRoute`s'
-            : whereFullscreenDialog!.describeMismatchAsString(
-                item.fullscreenDialog,
-                matchState,
-                verbose: verbose,
-              );
+        final mismatch =
+            item is! PageRoute
+                ? 'is not a property on `${item.runtimeType}` and can only be used '
+                    'with `PageRoute`s'
+                : whereFullscreenDialog!.describeMismatchAsString(
+                  item.fullscreenDialog,
+                  matchState,
+                  verbose: verbose,
+                );
         mismatchDescriptions.add('`fullscreenDialog` $mismatch');
       }
 

--- a/lib/src/mock_navigator.dart
+++ b/lib/src/mock_navigator.dart
@@ -133,10 +133,7 @@ class _MockNavigatorState extends NavigatorState {
     String routeName, {
     Object? arguments,
   }) {
-    return _navigator.pushNamed<T>(
-      routeName,
-      arguments: arguments,
-    );
+    return _navigator.pushNamed<T>(routeName, arguments: arguments);
   }
 
   @override
@@ -157,10 +154,7 @@ class _MockNavigatorState extends NavigatorState {
     Route<T> newRoute, {
     TO? result,
   }) {
-    return _navigator.pushReplacement<T, TO>(
-      newRoute,
-      result: result,
-    );
+    return _navigator.pushReplacement<T, TO>(newRoute, result: result);
   }
 
   @override
@@ -214,10 +208,7 @@ class _MockNavigatorState extends NavigatorState {
     Route<T> newRoute,
     RoutePredicate predicate,
   ) {
-    return _navigator.pushAndRemoveUntil<T>(
-      newRoute,
-      predicate,
-    );
+    return _navigator.pushAndRemoveUntil<T>(newRoute, predicate);
   }
 
   @override
@@ -238,10 +229,7 @@ class _MockNavigatorState extends NavigatorState {
     RestorableRouteBuilder<T> routeBuilder, {
     Object? arguments,
   }) {
-    return _navigator.restorablePush<T>(
-      routeBuilder,
-      arguments: arguments,
-    );
+    return _navigator.restorablePush<T>(routeBuilder, arguments: arguments);
   }
 
   @override
@@ -262,10 +250,7 @@ class _MockNavigatorState extends NavigatorState {
     String routeName, {
     Object? arguments,
   }) {
-    return _navigator.restorablePushNamed<T>(
-      routeName,
-      arguments: arguments,
-    );
+    return _navigator.restorablePushNamed<T>(routeName, arguments: arguments);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.6.0
 homepage: https://github.com/VeryGoodOpenSource/mockingjay
 
 environment:
-  sdk: ^3.5.0
-  flutter: ^3.24.0
+  sdk: ^3.7.0
+  flutter: ^3.29.0
 
 dependencies:
   flutter:

--- a/test/src/example_test.dart
+++ b/test/src/example_test.dart
@@ -51,11 +51,7 @@ void main() {
 
     verify(
       () => navigator.push<void>(
-        any(
-          that: isRoute<void>(
-            whereName: equals('/settings'),
-          ),
-        ),
+        any(that: isRoute<void>(whereName: equals('/settings'))),
       ),
     ).called(1);
   });

--- a/test/src/matchers_test.dart
+++ b/test/src/matchers_test.dart
@@ -38,10 +38,7 @@ void main() {
         bool fullscreenDialog = false,
       }) {
         return MaterialPageRoute<T>(
-          settings: RouteSettings(
-            name: name,
-            arguments: arguments,
-          ),
+          settings: RouteSettings(name: name, arguments: arguments),
           maintainState: maintainState,
           fullscreenDialog: fullscreenDialog,
           builder: (_) => const SizedBox(),
@@ -62,20 +59,17 @@ void main() {
           );
         });
 
-        test(
-          'throws AssertionError when both whereSettings '
-          'and whereName or whereArguments matchers are provided',
-          () {
-            expect(
-              () => isRoute(
-                whereSettings: isNotNull,
-                whereName: isNotNull,
-                whereArguments: isNotNull,
-              ),
-              throwsAssertionError,
-            );
-          },
-        );
+        test('throws AssertionError when both whereSettings '
+            'and whereName or whereArguments matchers are provided', () {
+          expect(
+            () => isRoute(
+              whereSettings: isNotNull,
+              whereName: isNotNull,
+              whereArguments: isNotNull,
+            ),
+            throwsAssertionError,
+          );
+        });
       });
 
       group('without arguments', () {
@@ -144,43 +138,43 @@ void main() {
           expect(
             createRoute<dynamic>(name: '/test'),
             isRoute(
-              whereSettings:
-                  isA<RouteSettings>().having((s) => s.name, 'name', '/test'),
+              whereSettings: isA<RouteSettings>().having(
+                (s) => s.name,
+                'name',
+                '/test',
+              ),
             ),
           );
         });
 
-        test(
-          'does not match anything that is not a route '
-          'with matching settings',
-          () {
-            expectToFail(
-              createRoute<dynamic>(name: '/test'),
-              isRoute(whereSettings: equalsSettingsOf(createRoute<String>())),
-              withMessage:
-                  "is a route where `settings` has `name` with value '/test'",
-            );
-            expectToFail(
-              createRoute<dynamic>(name: '/other_name'),
-              isRoute(
-                whereSettings: equalsSettingsOf(
-                  createRoute<dynamic>(name: '/test'),
-                ),
+        test('does not match anything that is not a route '
+            'with matching settings', () {
+          expectToFail(
+            createRoute<dynamic>(name: '/test'),
+            isRoute(whereSettings: equalsSettingsOf(createRoute<String>())),
+            withMessage:
+                "is a route where `settings` has `name` with value '/test'",
+          );
+          expectToFail(
+            createRoute<dynamic>(name: '/other_name'),
+            isRoute(
+              whereSettings: equalsSettingsOf(
+                createRoute<dynamic>(name: '/test'),
               ),
-              withMessage: '''
+            ),
+            withMessage: '''
 is a route where `settings` has `name` with value '/other_name' which is different.
           Expected: /test
             Actual: /other_name ...
                      ^
            Differ at offset 1''',
-            );
-            expectToFail(
-              1,
-              isRoute(whereSettings: equalsSettingsOf(createRoute<dynamic>())),
-              withMessage: 'is not a route but an instance of `int`',
-            );
-          },
-        );
+          );
+          expectToFail(
+            1,
+            isRoute(whereSettings: equalsSettingsOf(createRoute<dynamic>())),
+            withMessage: 'is not a route but an instance of `int`',
+          );
+        });
       });
 
       group('with whereName argument', () {
@@ -238,13 +232,15 @@ is a route where the route's `name` is different.
             expectToFail(
               createRoute<dynamic>(arguments: {'a': 1}),
               isRoute(whereArguments: equals({'a': 2})),
-              withMessage: "is a route where the route's `arguments` "
+              withMessage:
+                  "is a route where the route's `arguments` "
                   "at location ['a'] is <1> instead of <2>",
             );
             expectToFail(
               createRoute<dynamic>(arguments: {'a': 1}),
               isRoute(whereArguments: equals({'b': 1})),
-              withMessage: "is a route where the route's `arguments` "
+              withMessage:
+                  "is a route where the route's `arguments` "
                   "is missing map key 'b'",
             );
             expectToFail(
@@ -258,36 +254,32 @@ is a route where the route's `name` is different.
 
       group('with whereMaintainState argument', () {
         test('matches any route with matching maintainState argument', () {
-          expect(
-            createRoute<dynamic>(),
-            isRoute(whereMaintainState: isTrue),
-          );
+          expect(createRoute<dynamic>(), isRoute(whereMaintainState: isTrue));
         });
 
-        test(
-          'does not match anything that is not a route with matching '
-          'maintainState argument',
-          () {
-            expectToFail(
-              createRoute<dynamic>(),
-              isRoute(whereMaintainState: isFalse),
-              withMessage: 'is a route where `maintainState` '
-                  'is true instead of false',
-            );
-            expectToFail(
-              NonModalRoute(),
-              isRoute(whereMaintainState: isTrue),
-              withMessage: 'is a route where `maintainState` '
-                  'is not a property on `NonModalRoute` and can only be used '
-                  'with `ModalRoute`s',
-            );
-            expectToFail(
-              1,
-              isRoute(whereMaintainState: isTrue),
-              withMessage: 'is not a route but an instance of `int`',
-            );
-          },
-        );
+        test('does not match anything that is not a route with matching '
+            'maintainState argument', () {
+          expectToFail(
+            createRoute<dynamic>(),
+            isRoute(whereMaintainState: isFalse),
+            withMessage:
+                'is a route where `maintainState` '
+                'is true instead of false',
+          );
+          expectToFail(
+            NonModalRoute(),
+            isRoute(whereMaintainState: isTrue),
+            withMessage:
+                'is a route where `maintainState` '
+                'is not a property on `NonModalRoute` and can only be used '
+                'with `ModalRoute`s',
+          );
+          expectToFail(
+            1,
+            isRoute(whereMaintainState: isTrue),
+            withMessage: 'is not a route but an instance of `int`',
+          );
+        });
       });
 
       group('with whereFullscreenDialog argument', () {
@@ -298,30 +290,29 @@ is a route where the route's `name` is different.
           );
         });
 
-        test(
-          'does not match anything that is not a route with matching '
-          'fullscreenDialog argument',
-          () {
-            expectToFail(
-              createRoute<dynamic>(fullscreenDialog: true),
-              isRoute(whereFullscreenDialog: isFalse),
-              withMessage: 'is a route where `fullscreenDialog` '
-                  'is true instead of false',
-            );
-            expectToFail(
-              NonModalRoute(),
-              isRoute(whereFullscreenDialog: isFalse),
-              withMessage: 'is a route where `fullscreenDialog` '
-                  'is not a property on `NonModalRoute` and can only be used '
-                  'with `PageRoute`s',
-            );
-            expectToFail(
-              1,
-              isRoute(whereFullscreenDialog: isTrue),
-              withMessage: 'is not a route but an instance of `int`',
-            );
-          },
-        );
+        test('does not match anything that is not a route with matching '
+            'fullscreenDialog argument', () {
+          expectToFail(
+            createRoute<dynamic>(fullscreenDialog: true),
+            isRoute(whereFullscreenDialog: isFalse),
+            withMessage:
+                'is a route where `fullscreenDialog` '
+                'is true instead of false',
+          );
+          expectToFail(
+            NonModalRoute(),
+            isRoute(whereFullscreenDialog: isFalse),
+            withMessage:
+                'is a route where `fullscreenDialog` '
+                'is not a property on `NonModalRoute` and can only be used '
+                'with `PageRoute`s',
+          );
+          expectToFail(
+            1,
+            isRoute(whereFullscreenDialog: isTrue),
+            withMessage: 'is not a route but an instance of `int`',
+          );
+        });
       });
 
       test('returns all relevant mismatches in one log', () {

--- a/test/src/matchers_test.dart
+++ b/test/src/matchers_test.dart
@@ -45,8 +45,7 @@ void main() {
       }
 
       group('constructor', () {
-        test(
-            'throws AssertionError when both whereSettings '
+        test('throws AssertionError when both whereSettings '
             'and whereName or whereArguments matchers are provided', () {
           expect(
             () => isRoute(
@@ -134,8 +133,7 @@ void main() {
           );
         });
 
-        test(
-            'does not match anything that is not a route '
+        test('does not match anything that is not a route '
             'with matching settings', () {
           expectToFail(
             createRoute<dynamic>(name: '/test'),
@@ -220,13 +218,15 @@ is a route where the route's `name` is different.
             expectToFail(
               createRoute<dynamic>(arguments: {'a': 1}),
               isRoute(whereArguments: equals({'a': 2})),
-              withMessage: "is a route where the route's `arguments` "
+              withMessage:
+                  "is a route where the route's `arguments` "
                   "at location ['a'] is <1> instead of <2>",
             );
             expectToFail(
               createRoute<dynamic>(arguments: {'a': 1}),
               isRoute(whereArguments: equals({'b': 1})),
-              withMessage: "is a route where the route's `arguments` "
+              withMessage:
+                  "is a route where the route's `arguments` "
                   "is missing map key 'b'",
             );
             expectToFail(
@@ -243,19 +243,20 @@ is a route where the route's `name` is different.
           expect(createRoute<dynamic>(), isRoute(whereMaintainState: isTrue));
         });
 
-        test(
-            'does not match anything that is not a route with matching '
+        test('does not match anything that is not a route with matching '
             'maintainState argument', () {
           expectToFail(
             createRoute<dynamic>(),
             isRoute(whereMaintainState: isFalse),
-            withMessage: 'is a route where `maintainState` '
+            withMessage:
+                'is a route where `maintainState` '
                 'is true instead of false',
           );
           expectToFail(
             NonModalRoute(),
             isRoute(whereMaintainState: isTrue),
-            withMessage: 'is a route where `maintainState` '
+            withMessage:
+                'is a route where `maintainState` '
                 'is not a property on `NonModalRoute` and can only be used '
                 'with `ModalRoute`s',
           );
@@ -275,19 +276,20 @@ is a route where the route's `name` is different.
           );
         });
 
-        test(
-            'does not match anything that is not a route with matching '
+        test('does not match anything that is not a route with matching '
             'fullscreenDialog argument', () {
           expectToFail(
             createRoute<dynamic>(fullscreenDialog: true),
             isRoute(whereFullscreenDialog: isFalse),
-            withMessage: 'is a route where `fullscreenDialog` '
+            withMessage:
+                'is a route where `fullscreenDialog` '
                 'is true instead of false',
           );
           expectToFail(
             NonModalRoute(),
             isRoute(whereFullscreenDialog: isFalse),
-            withMessage: 'is a route where `fullscreenDialog` '
+            withMessage:
+                'is a route where `fullscreenDialog` '
                 'is not a property on `NonModalRoute` and can only be used '
                 'with `PageRoute`s',
           );

--- a/test/src/mock_navigator_test.dart
+++ b/test/src/mock_navigator_test.dart
@@ -14,9 +14,7 @@ extension on WidgetTester {
         home: Scaffold(
           body: MockNavigatorProvider(
             navigator: navigator,
-            child: Builder(
-              builder: builder,
-            ),
+            child: Builder(builder: builder),
           ),
         ),
       ),
@@ -30,9 +28,7 @@ void main() {
 
     const testRouteName = '__test_route__';
     final testRoute = MaterialPageRoute<void>(
-      settings: const RouteSettings(
-        name: testRouteName,
-      ),
+      settings: const RouteSettings(name: testRouteName),
       builder: (_) => const Text(testRouteName),
     );
     bool testRoutePredicate(Route<dynamic> _) => false;
@@ -49,10 +45,7 @@ void main() {
     });
 
     test('toString returns normally', () {
-      expect(
-        () => navigator.toString(),
-        returnsNormally,
-      );
+      expect(() => navigator.toString(), returnsNormally);
     });
 
     testWidgets('mocks .push calls', (tester) async {
@@ -60,10 +53,11 @@ void main() {
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).push(testRoute),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed: () => Navigator.of(context).push(testRoute),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -75,10 +69,11 @@ void main() {
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).pushNamed(testRouteName),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed: () => Navigator.of(context).pushNamed(testRouteName),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -86,18 +81,20 @@ void main() {
     });
 
     testWidgets('mocks .pushNamedAndRemoveUntil calls', (tester) async {
-      when(() => navigator.pushNamedAndRemoveUntil(any(), any()))
-          .thenAnswer((_) async => null);
+      when(
+        () => navigator.pushNamedAndRemoveUntil(any(), any()),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).pushNamedAndRemoveUntil(
-            testRouteName,
-            testRoutePredicate,
-          ),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(
+                    context,
+                  ).pushNamedAndRemoveUntil(testRouteName, testRoutePredicate),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -110,15 +107,17 @@ void main() {
     });
 
     testWidgets('mocks .pushReplacement calls', (tester) async {
-      when(() => navigator.pushReplacement<void, Object?>(any()))
-          .thenAnswer((_) async {});
+      when(
+        () => navigator.pushReplacement<void, Object?>(any()),
+      ).thenAnswer((_) async {});
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).pushReplacement(testRoute),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed: () => Navigator.of(context).pushReplacement(testRoute),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -126,16 +125,19 @@ void main() {
     });
 
     testWidgets('mocks .pushReplacementNamed calls', (tester) async {
-      when(() => navigator.pushReplacementNamed(any()))
-          .thenAnswer((_) async => null);
+      when(
+        () => navigator.pushReplacementNamed(any()),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () =>
-              Navigator.of(context).pushReplacementNamed(testRouteName),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () =>
+                      Navigator.of(context).pushReplacementNamed(testRouteName),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -147,10 +149,11 @@ void main() {
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).pop(testRoute),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed: () => Navigator.of(context).pop(testRoute),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -158,15 +161,18 @@ void main() {
     });
 
     testWidgets('mocks .popAndPushNamed calls', (tester) async {
-      when(() => navigator.popAndPushNamed(any()))
-          .thenAnswer((_) async => null);
+      when(
+        () => navigator.popAndPushNamed(any()),
+      ).thenAnswer((_) async => null);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).popAndPushNamed(testRouteName),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(context).popAndPushNamed(testRouteName),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -178,10 +184,12 @@ void main() {
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).popUntil(testRoutePredicate),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(context).popUntil(testRoutePredicate),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -193,10 +201,11 @@ void main() {
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).canPop(),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed: () => Navigator.of(context).canPop(),
+              child: const Text('Trigger'),
+            ),
       );
 
       // Called by NavigatorState.didChangeDependencies initially
@@ -210,10 +219,11 @@ void main() {
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).maybePop(),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed: () => Navigator.of(context).maybePop(),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -221,15 +231,17 @@ void main() {
     });
 
     testWidgets('mocks .maybePop calls w/result', (tester) async {
-      when(() => navigator.maybePop<bool>(any<bool>()))
-          .thenAnswer((_) async => true);
+      when(
+        () => navigator.maybePop<bool>(any<bool>()),
+      ).thenAnswer((_) async => true);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).maybePop(true),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed: () => Navigator.of(context).maybePop(true),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -237,76 +249,90 @@ void main() {
     });
 
     testWidgets('mocks .pushAndRemoveUntil calls', (tester) async {
-      when(() => navigator.pushAndRemoveUntil<void>(any(), any()))
-          .thenAnswer((_) async {});
+      when(
+        () => navigator.pushAndRemoveUntil<void>(any(), any()),
+      ).thenAnswer((_) async {});
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context)
-              .pushAndRemoveUntil(testRoute, testRoutePredicate),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(
+                    context,
+                  ).pushAndRemoveUntil(testRoute, testRoutePredicate),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
       verify(
-        () => navigator.pushAndRemoveUntil(
-          testRoute,
-          testRoutePredicate,
-        ),
+        () => navigator.pushAndRemoveUntil(testRoute, testRoutePredicate),
       ).called(1);
     });
 
     testWidgets('mocks .restorablePopAndPushNamed calls', (tester) async {
-      when(() => navigator.restorablePopAndPushNamed(any()))
-          .thenReturn(testRouteName);
+      when(
+        () => navigator.restorablePopAndPushNamed(any()),
+      ).thenReturn(testRouteName);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () =>
-              Navigator.of(context).restorablePopAndPushNamed(testRouteName),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(
+                    context,
+                  ).restorablePopAndPushNamed(testRouteName),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
-      verify(() => navigator.restorablePopAndPushNamed(testRouteName))
-          .called(1);
+      verify(
+        () => navigator.restorablePopAndPushNamed(testRouteName),
+      ).called(1);
     });
 
     testWidgets('mocks .restorablePush calls', (tester) async {
-      when(() => navigator.restorablePush<void>(any()))
-          .thenReturn(testRouteName);
+      when(
+        () => navigator.restorablePush<void>(any()),
+      ).thenReturn(testRouteName);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () =>
-              Navigator.of(context).restorablePush(restorableTestRouteBuilder),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(
+                    context,
+                  ).restorablePush(restorableTestRouteBuilder),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
-      verify(() => navigator.restorablePush(restorableTestRouteBuilder))
-          .called(1);
+      verify(
+        () => navigator.restorablePush(restorableTestRouteBuilder),
+      ).called(1);
     });
 
     testWidgets('mocks .restorablePushAndRemoveUntil calls', (tester) async {
-      when(() => navigator.restorablePushAndRemoveUntil<void>(any(), any()))
-          .thenReturn(testRouteName);
+      when(
+        () => navigator.restorablePushAndRemoveUntil<void>(any(), any()),
+      ).thenReturn(testRouteName);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).restorablePushAndRemoveUntil(
-            restorableTestRouteBuilder,
-            testRoutePredicate,
-          ),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(context).restorablePushAndRemoveUntil(
+                    restorableTestRouteBuilder,
+                    testRoutePredicate,
+                  ),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -319,37 +345,43 @@ void main() {
     });
 
     testWidgets('mocks .restorablePushNamed calls', (tester) async {
-      when(() => navigator.restorablePushNamed(any()))
-          .thenReturn(testRouteName);
+      when(
+        () => navigator.restorablePushNamed(any()),
+      ).thenReturn(testRouteName);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () =>
-              Navigator.of(context).restorablePushNamed(testRouteName),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () =>
+                      Navigator.of(context).restorablePushNamed(testRouteName),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
       verify(() => navigator.restorablePushNamed(testRouteName)).called(1);
     });
 
-    testWidgets('mocks .restorablePushNamedAndRemoveUntil calls',
-        (tester) async {
-      when(() => navigator.restorablePushNamedAndRemoveUntil(any(), any()))
-          .thenReturn(testRouteName);
+    testWidgets('mocks .restorablePushNamedAndRemoveUntil calls', (
+      tester,
+    ) async {
+      when(
+        () => navigator.restorablePushNamedAndRemoveUntil(any(), any()),
+      ).thenReturn(testRouteName);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () =>
-              Navigator.of(context).restorablePushNamedAndRemoveUntil(
-            testRouteName,
-            testRoutePredicate,
-          ),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(context).restorablePushNamedAndRemoveUntil(
+                    testRouteName,
+                    testRoutePredicate,
+                  ),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -362,16 +394,20 @@ void main() {
     });
 
     testWidgets('mocks .restorablePushReplacement calls', (tester) async {
-      when(() => navigator.restorablePushReplacement<void, Object?>(any()))
-          .thenReturn(testRouteName);
+      when(
+        () => navigator.restorablePushReplacement<void, Object?>(any()),
+      ).thenReturn(testRouteName);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context)
-              .restorablePushReplacement(restorableTestRouteBuilder),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(
+                    context,
+                  ).restorablePushReplacement(restorableTestRouteBuilder),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -381,21 +417,26 @@ void main() {
     });
 
     testWidgets('mocks .restorablePushReplacementNamed calls', (tester) async {
-      when(() => navigator.restorablePushReplacementNamed(any()))
-          .thenReturn(testRouteName);
+      when(
+        () => navigator.restorablePushReplacementNamed(any()),
+      ).thenReturn(testRouteName);
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context)
-              .restorablePushReplacementNamed(testRouteName),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(
+                    context,
+                  ).restorablePushReplacementNamed(testRouteName),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
-      verify(() => navigator.restorablePushReplacementNamed(testRouteName))
-          .called(1);
+      verify(
+        () => navigator.restorablePushReplacementNamed(testRouteName),
+      ).called(1);
     });
 
     testWidgets('mocks .restorableReplace calls', (tester) async {
@@ -408,13 +449,15 @@ void main() {
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).restorableReplace(
-            oldRoute: testRoute,
-            newRouteBuilder: restorableTestRouteBuilder,
-          ),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(context).restorableReplace(
+                    oldRoute: testRoute,
+                    newRouteBuilder: restorableTestRouteBuilder,
+                  ),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));
@@ -436,13 +479,15 @@ void main() {
 
       await tester.pumpTest(
         navigator: navigator,
-        builder: (context) => TextButton(
-          onPressed: () => Navigator.of(context).restorableReplaceRouteBelow(
-            anchorRoute: testRoute,
-            newRouteBuilder: restorableTestRouteBuilder,
-          ),
-          child: const Text('Trigger'),
-        ),
+        builder:
+            (context) => TextButton(
+              onPressed:
+                  () => Navigator.of(context).restorableReplaceRouteBelow(
+                    anchorRoute: testRoute,
+                    newRouteBuilder: restorableTestRouteBuilder,
+                  ),
+              child: const Text('Trigger'),
+            ),
       );
 
       await tester.tap(find.byType(TextButton));


### PR DESCRIPTION
## Status

**READY**

## Description

- Bumping flutter version from 3.24.0 to 3.29.0
- Bumping min Dart SDK version from 3.5.0 to 3.7.0
- Bumping `flutter_bloc`, `bloc` and `bloc_test`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
