### PR TITLE
chore: remove Flutter upper bound

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/VeryGoodOpenSource/mockingjay
 
 environment:
   sdk: ^3.10.0
-  flutter: ^3.38.1
+  flutter: ">=3.38.1"
 
 dependencies:
   flutter:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->

Removes Flutter's upper bound as enforced by pub dev. 

See error here: https://github.com/VeryGoodOpenSource/mockingjay/actions/runs/19864312698/job/56922610027

<!--- Put an `x` in all the boxes that apply: -->

- [x] 🗑️ Chore
